### PR TITLE
Externally-reported Moderate severity vulnerability in SMS

### DIFF
--- a/src/java/com/android/internal/telephony/SMSDispatcher.java
+++ b/src/java/com/android/internal/telephony/SMSDispatcher.java
@@ -78,8 +78,8 @@ public abstract class SMSDispatcher extends Handler {
     private static final String SEND_NEXT_MSG_EXTRA = "SendNextMsg";
 
     /** Permission required to send SMS to short codes without user confirmation. */
-    private static final String SEND_SMS_NO_CONFIRMATION_PERMISSION =
-            "android.permission.SEND_SMS_NO_CONFIRMATION";
+    private static final String SEND_RESPOND_VIA_MESSAGE_PERMISSION =
+            "android.permission.SEND_RESPOND_VIA_MESSAGE";
 
     private static final int PREMIUM_RULE_USE_SIM = 1;
     private static final int PREMIUM_RULE_USE_NETWORK = 2;
@@ -721,7 +721,7 @@ public abstract class SMSDispatcher extends Handler {
      * @return true if the destination is approved; false if user confirmation event was sent
      */
     boolean checkDestination(SmsTracker tracker) {
-        if (mContext.checkCallingOrSelfPermission(SEND_SMS_NO_CONFIRMATION_PERMISSION)
+        if (mContext.checkCallingOrSelfPermission(SEND_RESPOND_VIA_MESSAGE_PERMISSION)
                 == PackageManager.PERMISSION_GRANTED) {
             return true;            // app is pre-approved to send to short codes
         } else {


### PR DESCRIPTION
Apps can bypass the SMS short code notification prompt

Bug 22314646

When android.permission.SEND_SMS_NO_CONFIRMATION was renamed to
android.permission.SEND_RESPOND_VIA_MESSAGE in JB-MR2, the necessary change
in SmsDispatcher was accidentally overlooked.

CVE-2015-3858: Elevation of Privilege vulnerability in SMS enables
notification bypass.

Change-Id: I2c3aa79da8064e55cec5a786696de519c2bf0b07
